### PR TITLE
[tests] Make tests more portable

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -61,4 +61,4 @@ else
     printf 'Failing tests: %s\n' "$FAILING_TESTS"
 fi
 
-return $FAILURE
+exit $FAILURE


### PR DESCRIPTION
You cannot /return/ from a shell script. However, you can exit. Return
only works within functions. It may be that some sh implementations
allow top-level returns as an extension, but it is not portable.

Example test run with parent tree:

	$ make test
	(cd tests; ./run_tests.sh)
	...................................................................
	All 67 tests passed
	./run_tests.sh: line 64: return: can only `return' from a function or sourced script
	make: *** [Makefile:134: test] Error 1

tests/run_tests.sh:
	As above.