### PR TITLE
[build] Skip building documentation if asciidoc isn't available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .dep
+.docs_warning

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,12 @@ ifeq ($(PZ_DEV),yes)
 else
 endif
 
+ifneq ($(shell which asciidoc),)
+	DOCS_TARGETS=$(DOCS_HTML)
+else
+	DOCS_TARGETS=.docs_warning
+endif
+
 CFLAGS=$(DEPFLAGS) $(C_CXX_WARN_FLAGS) $(C_CXX_FLAGS) $(C_ONLY_FLAGS)
 CXXFLAGS=$(DEPFLAGS) $(C_CXX_WARN_FLAGS) $(C_CXX_FLAGS) $(CXX_ONLY_FLAGS)
 $(shell mkdir -p $(DEPDIR)/runtime >/dev/null)
@@ -173,7 +179,14 @@ runtime/tags: $(CXX_SOURCES) $(C_SOURCES) $(C_HEADERS)
 	(cd runtime; ctags *.cpp *.c *.h)
 
 .PHONY: docs
-docs : $(DOCS_HTML)
+docs : $(DOCS_TARGETS)
+
+.docs_warning :
+	@echo
+	@echo Warning: asciidoc not found, not building documentation.
+	@echo --------------------------------------------------------
+	@echo
+	touch .docs_warning
 
 %.html : %.txt docs/asciidoc.conf
 	asciidoc --conf-file docs/asciidoc.conf  -o $@ $<
@@ -221,6 +234,7 @@ localclean:
 	rm -rf src/*.err src/*.mh
 	rm -rf runtime/*.o
 	rm -rf examples/*.pz examples/*.diff examples/*.out
+	rm -rf .docs_warning
 	rm -rf $(DEPDIR)
 
 # Nither formatting tool does a perfect job, but clang-format seems to be


### PR DESCRIPTION
Skip building the documentation and give a warning if asciidoc is not in
the path.

Closes #96

Makefile:
    As above.

.gitignore:
    Ignore a new sentinel file.