### PR TITLE
Add a script for building the compiler from within vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ things are working correctly.
 * [docs](docs) - Documentation
 * [examples](examples) - Example Plasma programs
 * [runtime](runtime) - Runtime system (C code)
+* [scripts](scripts) - Some scripts to aid developers
 * [src](src) - The compiler and other tools
 * [tests](tests) - The test suite (in addition to some of the files in
   [examples](examples))

--- a/docs/getting_started.txt
+++ b/docs/getting_started.txt
@@ -8,7 +8,13 @@ Getting started with Plasma
 :License: CC BY-SA 4.0
 
 Since we don’t have static builds yet, you’ll need to build Plasma from source.
-For that you’ll need Mercury, since our compiler is written in it.
+This file contains some instructions on setting up the prerequisites and
+buidling Plasma.
+
+Mercury
+-------
+
+You’ll need another language, Mercury, since our compiler is written in it.
 Version 14.01.1 or newer is required but an ROTD version is recommended
 since the stable release is quite old and may be less compatible with newer
 C compilers.  An ROTD version is required for musl-based systems.
@@ -18,8 +24,7 @@ but if you’re on Debian, Ubuntu or other derivative running on x86_64
 then there are some packages!
 Read on or follow the instructions at https://dl.mercurylang.org/deb/
 
-For Ubuntu 18.04, this is what you need to do:
-----------------------------------------------
+=== For Ubuntu 18.04, this is what you need to do:
 
 You’ll need a basic C and C++ build environment. That can be installed with
 the build-essential:
@@ -54,15 +59,8 @@ sudo apt install mercury-rotd-recommended
 
 If all goes well you now have a working version of Mercury on your computer.
 
-Now it’s time to clone the plasma repo:
-
-[source,bash]
-----
-git clone https://github.com/PlasmaLang/plasma.git
-----
-Now you can configure the Makefile if you want to. In the Makefile itself is
-documentation that explains what options make what build. The default build
-is probably fine, so you shouldn’t have to configure anything really.
+Asciidoc
+--------
 
 To optionally build the documentation, you want to install AsciiDoc:
 
@@ -74,9 +72,6 @@ sudo apt install asciidoc
 Beware, this is a very large installation, on a default Ubuntu installation
 this amounts to over 1 GB of space and a download of over 300MB.  If
 AsciiDoc is not installed, documentation will not be built.
-
-Then run `make` and it will build you the plasma compiler (`src/plzc`)
-and the runtime (`runtime/plzrun`)
 
 Docker
 ------
@@ -103,5 +98,21 @@ The rotd version of Mercury could probably be more recent, depending on when
 you are reading this.  Note that this is just for running Plasma programs,
 not for hacking on Plasma itself. The minimal install of mercury doesn’t
 allow for debugging the Plasma compiler.
+
+Plasma
+------
+
+Now it’s time to clone the plasma repo:
+
+[source,bash]
+----
+git clone https://github.com/PlasmaLang/plasma.git
+----
+Now you can configure the Makefile if you want to. In the Makefile itself is
+documentation that explains what options make what build. The default build
+is probably fine, so you shouldn’t have to configure anything really.
+
+Then run `make` and it will build you the plasma compiler (`src/plzc`)
+and the runtime (`runtime/plzrun`)
 
 // vim: set syntax=asciidoc:

--- a/docs/getting_started.txt
+++ b/docs/getting_started.txt
@@ -68,6 +68,9 @@ distribution](https://github.com/Mercury-Language/mercury/tree/master/vim)
 if you've used the Debian package it's at
 `/usr/share/doc/mercury-rotd-tools/examples/vim/`
 
+You may also wish to use [extra script](../scripts) and configuration change
+to make it easier to build the Mercury sources from within vim.
+
 Asciidoc
 --------
 

--- a/docs/getting_started.txt
+++ b/docs/getting_started.txt
@@ -59,6 +59,15 @@ sudo apt install mercury-rotd-recommended
 
 If all goes well you now have a working version of Mercury on your computer.
 
+=== vim
+
+If you'll be working on the compiler you probably want some editor support
+for Mercury.  Support is included in the 
+[Mercury repository/source
+distribution](https://github.com/Mercury-Language/mercury/tree/master/vim)
+if you've used the Debian package it's at
+`/usr/share/doc/mercury-rotd-tools/examples/vim/`
+
 Asciidoc
 --------
 
@@ -114,5 +123,11 @@ is probably fine, so you shouldn’t have to configure anything really.
 
 Then run `make` and it will build you the plasma compiler (`src/plzc`)
 and the runtime (`runtime/plzrun`)
+
+vim
+---
+
+If you want to write some Plasma programs and you use vim.  You may wish to
+use the [vim editor support](https://github.com/PlasmaLang/vim).
 
 // vim: set syntax=asciidoc:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,10 @@
+
+The [do_mmc_make](do_mmc_make) script in this directory can be placed in
+the path and will run the [.vim_mmc_make](../src/.vim_mmc_make) script
+from the current directory.
+Such as the one in the `src` directory.  This makes it easy to use `mmc
+--make` from vim by pressing F9 with the following configuration change.
+Make this change to the `ftplugin/mercury.vim` file of Mercury's vim plugin.
+
+    setlocal makeprg=do_mmc_make
+

--- a/scripts/do_mmc_make
+++ b/scripts/do_mmc_make
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ -f .vim_mmc_make ]; then
+    JOBS=8 exec ./.vim_mmc_make
+else
+    echo "No .vim_mmc_make file found"
+    exit 1
+fi
+

--- a/src/.vim_mmc_make
+++ b/src/.vim_mmc_make
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+MCFLAGS=--use-grade-subdirs
+
+for prog in plzc plzasm; do
+    mmc $MCFLAGS -j$JOBS --make $prog
+done
+
+


### PR DESCRIPTION
Add a small script to make it easier to build the compiler from within vim by pressing `F9`. then sowing the build errors within vim.

I've also updated the getting started guide with information about setting up vim.