### PR TITLE
src/pz.link.m: fix typo "too modules" -> "two ..." (also in tests)

### DIFF
--- a/src/pz.link.m
+++ b/src/pz.link.m
@@ -365,7 +365,7 @@ calculate_offsets_and_build_maps([Input | Inputs],
         true
     else
         compile_error($file, $pred,
-            "Cannot link too modules containing the same module")
+            "Cannot link two modules containing the same module")
     ),
 
     calculate_offsets_and_build_maps(Inputs,

--- a/tests/modules-invalid/module_05.exp
+++ b/tests/modules-invalid/module_05.exp
@@ -1,5 +1,5 @@
 A compilation error occured and this error is not handled gracefully
 by the Plasma bytecode linker. Sorry.
-Message:            Cannot link too modules containing the same module
+Message:            Cannot link two modules containing the same module
 plzlnk location:    predicate `pz.link.calculate_offsets_and_build_maps'/19
 plzlnk file:        pz.link.m


### PR DESCRIPTION
Trivial fix, doesn't warrant adding a line added to AUTHORS, I'd think. What do you think?