### PR TITLE
[docs] Change the author on the main Plasma documentation page

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -1,6 +1,6 @@
 Plasma Language Documentation
 =============================
-Gert Meulyzer <gert@plasmalang.org>
+Paul Bone <paul@plasmalang.org>
 v0.4, June 2019: Initial draft.
 Copyright (C) 2015-2019 Plasma Team
 License: CC BY-SA 4.0


### PR DESCRIPTION
Hi Gert,

I think at this point I've done the majority of the technical documentaiton.  it makes sense to change the author on the main page.  Your name is still on the pages that you authored.