### PR TITLE
[scripts] Fixed `make install` when no HTML docs exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ install_progs : install_dirs progs
 
 .PHONY: install_docs
 install_docs : install_dirs docs
-	cd docs/ ; for FILE in *.txt *.html; do \
+	cd docs/ ; for FILE in $$(find -name '*.txt' -o -name '*.html' ); do \
 		$(INSTALL) $$FILE $(DEST_DIR)$(DOCDIR); \
 	done
 	if [ -f docs/index.html ]; then \


### PR DESCRIPTION
This fixes #404

The warning that asciidoc is not installed only shows if `make` has
not already been run.